### PR TITLE
add memory allocation info to p2p benchmarks

### DIFF
--- a/src/imb_pingping.jl
+++ b/src/imb_pingping.jl
@@ -23,16 +23,19 @@ function imb_pingping(T::Type, bufsize::Int, iters::Int, comm::MPI.Comm)
     tag = 0
     timer = 0.0
     MPI.Barrier(comm)
-    for i in 1:iters
-        tic = MPI.Wtime()
-        request = MPI.Isend(send_buffer, comm; dest, tag)
-        MPI.Recv!(recv_buffer, comm; source, tag)
-        MPI.Wait(request)
-        toc = MPI.Wtime()
-        timer += toc - tic
+    alloc = @allocated begin
+        for i in 1:iters
+            tic = MPI.Wtime()
+            request = MPI.Isend(send_buffer, comm; dest, tag)
+            MPI.Recv!(recv_buffer, comm; source, tag)
+            MPI.Wait(request)
+            toc = MPI.Wtime()
+            timer += toc - tic
+        end
     end
     avgtime = timer / iters
-    return avgtime
+    avgalloc = alloc / iters
+    return avgtime, avgalloc
 end
 
 benchmark(bench::IMBPingPing) = run_imb_p2p(bench, imb_pingping, bench.conf)

--- a/src/imb_pingpong.jl
+++ b/src/imb_pingpong.jl
@@ -20,24 +20,28 @@ function imb_pingpong(T::Type, bufsize::Int, iters::Int, comm::MPI.Comm)
     buffer = zeros(T, bufsize)
     tag = 0
     timer = 0.0
+    alloc = 0
     MPI.Barrier(comm)
-    for i in 1:iters
-        tic = MPI.Wtime()
-        if iszero(rank)
-            MPI.Send(buffer, comm; dest=1, tag)
-            MPI.Recv!(buffer, comm; source=1, tag)
-        elseif isone(rank)
-            # Note: this branch must run on rank 1 only: if the benchmark is run with more
-            # than 2 MPI ranks, the other ranks would wait indefinitely for a message from
-            # rank 0.
-            MPI.Recv!(buffer, comm; source=0, tag)
-            MPI.Send(buffer, comm; dest=0, tag)
+    alloc = @allocated begin
+        for i in 1:iters
+            tic = MPI.Wtime()
+            if iszero(rank)
+                MPI.Send(buffer, comm; dest=1, tag)
+                MPI.Recv!(buffer, comm; source=1, tag)
+            elseif isone(rank)
+                # Note: this branch must run on rank 1 only: if the benchmark is run with more
+                # than 2 MPI ranks, the other ranks would wait indefinitely for a message from
+                # rank 0.
+                MPI.Recv!(buffer, comm; source=0, tag)
+                MPI.Send(buffer, comm; dest=0, tag)
+            end
+            toc = MPI.Wtime()
+            timer += toc - tic
         end
-        toc = MPI.Wtime()
-        timer += toc - tic
     end
     avgtime = timer / iters
-    return avgtime
+    avgalloc = alloc / iters
+    return avgtime, avgalloc
 end
 
 benchmark(bench::IMBPingPong) = run_imb_p2p(bench, imb_pingpong, bench.conf; divide_latency_by_two=true)


### PR DESCRIPTION
The Request objects appear to be allocating memory:

```
├ mpiexecjl -n 2 julia --project -e 'using MPIBenchmarks; benchmark(IMBPingPing())'
----------------------------------------
Running benchmark IMB Pingping with type UInt8 on 2 MPI ranks

size (bytes),iterations,time (seconds),throughput (MB/s),alloc (B)
0,1048576,2.34134006500881e-6,0.0,128.64767169952393
1,1048576,9.321231842229511e-7,1.0728195767747513,128.0
2,1048576,8.767032623412888e-7,2.2812735915443954,128.0
4,1048576,8.803138732917017e-7,4.543833877163669,128.0
8,1048576,8.131074905476116e-7,9.838797567357497,128.0
16,1048576,8.747806549034513e-7,18.290299299960978,128.0
32,1048576,9.733982086655105e-7,32.87452115190422,128.0
64,1048576,8.948459625118289e-7,71.52068923723171,128.0
128,1048576,8.989925384618371e-7,142.38160443356526,128.0
256,1048576,8.937778472944621e-7,286.42464206842084,128.0
512,1048576,9.398517608687987e-7,544.7667614376838,128.0
1024,1048576,1.0895824432107567e-6,939.809563177707,128.0
2048,524288,1.9520435332949677e-6,1049.1569296833568,128.0
4096,262144,2.5500640869211347e-6,1606.2341417251905,128.0
8192,131072,2.36920928953048e-6,3457.6936854841797,128.0
16384,65536,3.312423706207379e-6,4946.227129487358,128.0
32768,32768,5.272247314724865e-6,6215.186436433325,128.0
65536,16384,1.8652038573818697e-5,3513.6105761646295,128.0
131072,8192,2.805700683577994e-5,4671.631609429174,128.0
262144,4096,4.387573242142784e-5,5974.692285067708,128.0
524288,2048,7.960302734244529e-5,6586.282174226348,128.0
1048576,1024,0.00016257910156269872,6449.6358383160095,128.0
2097152,512,0.00043201367187295503,4854.3648882869675,128.0
4194304,256,0.000739679687497663,5670.432852075922,128.0
----------------------------------------
```