### PR TITLE
Added One-sided benchmarks for Get and Put

### DIFF
--- a/src/MPIBenchmarks.jl
+++ b/src/MPIBenchmarks.jl
@@ -11,6 +11,7 @@ struct Configuration{T}
     iters::Function
     stdout::IO
     filename::Union{String,Nothing}
+    synchronization_option::Union{String,Nothing}
 end
 
 function iterations(::Type{T}, s::Int) where {T}
@@ -24,6 +25,7 @@ function Configuration(T::Type;
                        verbose::Bool=true,
                        filename::Union{String,Nothing}=nothing,
                        iterations::Function=iterations,
+                       synchronization_option::Union{String,Nothing}="lock",
                        )
     ispow2(max_size) || throw(ArgumentError("Maximum size must be a power of 2, found $(max_size)"))
     isprimitivetype(T) || throw(ArgumentError("Type $(T) is not a primitive type"))
@@ -38,7 +40,7 @@ function Configuration(T::Type;
     if isnothing(stdout)
         stdout = verbose ? Base.stdout : Base.devnull
     end
-    return Configuration(T, lengths, iterations, stdout, filename)
+    return Configuration(T, lengths, iterations, stdout, filename, synchronization_option)
 end
 
 """
@@ -53,5 +55,7 @@ include("imb_p2p.jl")
 
 include("osu_collective.jl")
 include("osu_p2p.jl")
+
+include("osu_one_sided.jl")
 
 end

--- a/src/osu_get_latency.jl
+++ b/src/osu_get_latency.jl
@@ -1,0 +1,81 @@
+export OSUGetLatency
+
+struct OSUGetLatency <: MPIBenchmark
+    conf::Configuration
+    name::String
+end
+
+function OSUGetLatency(T::Type=Float32;
+                     filename::Union{String,Nothing}="julia_osu_get_latency.csv",
+                     kwargs...,
+                     )
+    return OSUGetLatency(
+        Configuration(T; filename, max_size=2 ^ 20, kwargs...),
+        "OSU Get Latency",
+    )
+end
+
+function osu_get_latency(T::Type, bufsize::Int, iters::Int, comm::MPI.Comm, synchronization_option::String)
+    win = MPI.Win_create(ones(T, bufsize), comm)
+    if(synchronization_option == "lock")
+       return run_get_with_lock(T, bufsize, iters, comm, win)
+    elseif(synchronization_option == "fence")
+       return run_get_with_fence(T, bufsize, iters, comm, win)
+    end
+end
+
+function run_get_with_lock(T::Type, bufsize::Int, iters::Int, comm::MPI.Comm, win::MPI.Win)
+    rank = MPI.Comm_rank(comm)
+    buffer = ones(T, bufsize)
+    root = 0
+    timer = 0.0    
+    tic = 0.0
+    if rank == root
+        for i in 1:iters
+            if i == 1
+                tic = MPI.Wtime()
+            end
+            MPI.Win_lock(MPI.LOCK_SHARED, 1, 0, win)
+            MPI.Get!(buffer, 1, 0, win)   #Parameter: data, rank, disp, win
+            MPI.Win_unlock(1, win)
+        end
+        toc = MPI.Wtime()
+    end
+    MPI.Barrier(comm)
+    toc = MPI.Wtime()
+    timer = toc - tic
+    MPI.free(win)
+    return timer
+end
+
+function run_get_with_fence(T::Type, bufsize::Int, iters::Int, comm::MPI.Comm, win::MPI.Win)
+    rank = MPI.Comm_rank(comm)
+    buffer = ones(T, bufsize)
+    root = 0
+    timer = 0.0
+    tic = 0.0
+    if rank == root
+        for i in 1:iters
+            if i == 1
+                tic = MPI.Wtime()
+            end
+            MPI.Win_fence(0, win)
+            MPI.Get!(buffer, 1, 0, win)   #Parameter: data, rank, disp, win
+            MPI.Win_fence(0, win)
+        end
+        toc = MPI.Wtime()
+    else
+        for _ in 1:iters
+            MPI.Win_fence(0, win)
+            MPI.Get!(buffer, 0, 0, win)   #Parameter: data, rank, disp, win
+            MPI.Win_fence(0, win)
+        end
+    end
+    MPI.Barrier(comm)
+    toc = MPI.Wtime()
+    timer = toc - tic
+    MPI.free(win)
+    return timer
+end
+
+benchmark(bench::OSUGetLatency) = run_osu_one_sided(bench, osu_get_latency, bench.conf)

--- a/src/osu_get_latency.jl
+++ b/src/osu_get_latency.jl
@@ -28,7 +28,6 @@ function run_get_with_lock(T::Type, bufsize::Int, iters::Int, comm::MPI.Comm, wi
     rank = MPI.Comm_rank(comm)
     buffer = ones(T, bufsize)
     root = 0
-    timer = 0.0    
     tic = 0.0
     if rank == root
         for i in 1:iters
@@ -52,7 +51,6 @@ function run_get_with_fence(T::Type, bufsize::Int, iters::Int, comm::MPI.Comm, w
     rank = MPI.Comm_rank(comm)
     buffer = ones(T, bufsize)
     root = 0
-    timer = 0.0
     tic = 0.0
     if rank == root
         for i in 1:iters

--- a/src/osu_one_sided.jl
+++ b/src/osu_one_sided.jl
@@ -1,5 +1,5 @@
 function run_osu_one_sided(benchmark::MPIBenchmark, func::Function, conf::Configuration)
-    if (conf.synchronization_option !== "lock" && conf.synchronization_option !== "fence")
+    if conf.synchronization_option ∉ ("lock", "fence")
         error("The value of synchronization_option is incorrect. synchronization_option can be 'lock' or 'fence'")
     end
     MPI.Init()

--- a/src/osu_one_sided.jl
+++ b/src/osu_one_sided.jl
@@ -1,0 +1,65 @@
+function run_osu_one_sided(benchmark::MPIBenchmark, func::Function, conf::Configuration)
+    if (conf.synchronization_option !== "lock" && conf.synchronization_option !== "fence")
+        error("The value of synchronization_option is incorrect. synchronization_option can be 'lock' or 'fence'")
+    end
+    MPI.Init()
+    comm = MPI.COMM_WORLD
+    # Current rank
+    rank = MPI.Comm_rank(comm)
+    # Number of ranks
+    nranks = MPI.Comm_size(comm)
+    if nranks != 2
+        # Throw error only on rank 0, to avoid messy error messages
+        if iszero(rank)
+            error("OSU one-sided benchmarks require exactly 2 MPI ranks")
+        else
+            exit()
+        end
+    end
+
+    # Warmup
+    func(conf.T, 1, 10, comm, conf.synchronization_option)
+
+    if iszero(rank)
+        print_header(io) = println(io, "size (bytes),iterations,time (seconds)")
+        print_timings(io, bytes, iters, latency) = println(io, bytes, ",", iters, ",", latency,)
+
+        println(conf.stdout, "----------------------------------------")
+        println(conf.stdout, "Running benchmark ", benchmark.name, " with type ", conf.T, " on ", nranks, " MPI ranks ", "with window synchronization: ", conf.synchronization_option)
+        println(conf.stdout)
+        print_header(conf.stdout)
+        if !isnothing(conf.filename)
+            file = open(conf.filename, "w")
+            print_header(file)
+        end
+    end
+
+    for s in conf.lengths
+        size = 1 << s
+        iters = conf.iters(conf.T, s)
+        # Measure time on current rank
+        time = func(conf.T, size, iters, comm, conf.synchronization_option)
+
+        if rank == 0
+            latency = time * 1.0e6 / iters
+            bytes = size * sizeof(conf.T)
+            print_timings(conf.stdout, bytes, iters, latency)
+            if !isnothing(conf.filename)
+                print_timings(file, bytes, iters, latency)
+            end
+        end
+    end
+
+    if iszero(rank)
+        println(conf.stdout, "----------------------------------------")
+        if !isnothing(conf.filename)
+            close(file)
+        end
+    end
+
+    return nothing
+end
+
+
+include("osu_put_latency.jl")
+include("osu_get_latency.jl")

--- a/src/osu_put_latency.jl
+++ b/src/osu_put_latency.jl
@@ -1,0 +1,82 @@
+export OSUPutLatency
+
+struct OSUPutLatency <: MPIBenchmark
+    conf::Configuration
+    name::String
+end
+
+function OSUPutLatency(T::Type=Float32;
+                     filename::Union{String,Nothing}="julia_osu_put_latency.csv",
+                     kwargs...,
+                     )
+    return OSUPutLatency(
+        Configuration(T; filename, max_size=2 ^ 20, kwargs...),
+        "OSU Put Latency",
+    )
+end
+
+function osu_put_latency(T::Type, bufsize::Int, iters::Int, comm::MPI.Comm, synchronization_option::String)
+    win = MPI.Win_create(ones(T, bufsize), comm)
+    if(synchronization_option == "lock")
+       return run_put_with_lock(T, bufsize, iters, comm, win)
+    elseif(synchronization_option == "fence")
+       return run_put_with_fence(T, bufsize, iters, comm, win)
+    end
+end
+
+function run_put_with_lock(T::Type, bufsize::Int, iters::Int, comm::MPI.Comm, win::MPI.Win)
+    rank = MPI.Comm_rank(comm)
+    buffer = ones(T, bufsize)
+    root = 0
+    timer = 0.0    
+    tic = 0.0
+     
+    if rank == root
+        for i in 1:iters
+            if i == 1
+                tic = MPI.Wtime()
+            end
+            MPI.Win_lock(MPI.LOCK_SHARED , 1, 0, win)
+            MPI.Put!(buffer, 1, 0, win)   #Parameter: data, rank, disp, win
+            MPI.Win_unlock(1, win)
+        end
+        toc = MPI.Wtime()
+    end
+    MPI.Barrier(comm)
+    toc = MPI.Wtime()
+    timer = toc - tic
+    MPI.free(win)
+    return timer
+end
+
+function run_put_with_fence(T::Type, bufsize::Int, iters::Int, comm::MPI.Comm, win::MPI.Win)
+    rank = MPI.Comm_rank(comm)
+    buffer = ones(T, bufsize)
+    root = 0
+    timer = 0.0
+    tic = 0.0
+    if rank == root
+        for i in 1:iters
+            if i == 1
+                tic = MPI.Wtime()
+            end
+            MPI.Win_fence(0, win)
+            MPI.Put!(buffer, 1, 0, win)   #Parameter: data, rank, disp, win
+            MPI.Win_fence(0, win)
+        end
+        toc = MPI.Wtime()
+    else
+        for _ in 1:iters
+            MPI.Win_fence(0, win)
+            MPI.Put!(buffer, 0, 0, win)   #Parameter: data, rank, disp, win
+            MPI.Win_fence(0, win)
+        end
+    end
+    MPI.Barrier(comm)
+    toc = MPI.Wtime()
+    timer = toc - tic
+    MPI.free(win)
+    return timer
+end
+
+benchmark(bench::OSUPutLatency) = run_osu_one_sided(bench, osu_put_latency, bench.conf)

--- a/src/osu_put_latency.jl
+++ b/src/osu_put_latency.jl
@@ -17,9 +17,9 @@ end
 
 function osu_put_latency(T::Type, bufsize::Int, iters::Int, comm::MPI.Comm, synchronization_option::String)
     win = MPI.Win_create(ones(T, bufsize), comm)
-    if(synchronization_option == "lock")
+    if synchronization_option == "lock"
        return run_put_with_lock(T, bufsize, iters, comm, win)
-    elseif(synchronization_option == "fence")
+    elseif synchronization_option == "fence"
        return run_put_with_fence(T, bufsize, iters, comm, win)
     end
 end
@@ -28,14 +28,10 @@ function run_put_with_lock(T::Type, bufsize::Int, iters::Int, comm::MPI.Comm, wi
     rank = MPI.Comm_rank(comm)
     buffer = ones(T, bufsize)
     root = 0
-    timer = 0.0    
-    tic = 0.0
-     
+    tic = MPI.Wtime()
+
     if rank == root
         for i in 1:iters
-            if i == 1
-                tic = MPI.Wtime()
-            end
             MPI.Win_lock(MPI.LOCK_SHARED , 1, 0, win)
             MPI.Put!(buffer, 1, 0, win)   #Parameter: data, rank, disp, win
             MPI.Win_unlock(1, win)
@@ -53,7 +49,6 @@ function run_put_with_fence(T::Type, bufsize::Int, iters::Int, comm::MPI.Comm, w
     rank = MPI.Comm_rank(comm)
     buffer = ones(T, bufsize)
     root = 0
-    timer = 0.0
     tic = 0.0
     if rank == root
         for i in 1:iters

--- a/src/osu_put_latency.jl
+++ b/src/osu_put_latency.jl
@@ -28,15 +28,15 @@ function run_put_with_lock(T::Type, bufsize::Int, iters::Int, comm::MPI.Comm, wi
     rank = MPI.Comm_rank(comm)
     buffer = ones(T, bufsize)
     root = 0
+    MPI.Barrier(comm)
     tic = MPI.Wtime()
 
     if rank == root
-        for i in 1:iters
-            MPI.Win_lock(MPI.LOCK_SHARED , 1, 0, win)
+        for _ in 1:iters
+            MPI.Win_lock(MPI.LOCK_SHARED, 1, 0, win)
             MPI.Put!(buffer, 1, 0, win)   #Parameter: data, rank, disp, win
             MPI.Win_unlock(1, win)
         end
-        toc = MPI.Wtime()
     end
     MPI.Barrier(comm)
     toc = MPI.Wtime()
@@ -49,17 +49,14 @@ function run_put_with_fence(T::Type, bufsize::Int, iters::Int, comm::MPI.Comm, w
     rank = MPI.Comm_rank(comm)
     buffer = ones(T, bufsize)
     root = 0
-    tic = 0.0
+    MPI.Barrier(comm)
+    tic = MPI.Wtime()
     if rank == root
-        for i in 1:iters
-            if i == 1
-                tic = MPI.Wtime()
-            end
+        for _ in 1:iters
             MPI.Win_fence(0, win)
             MPI.Put!(buffer, 1, 0, win)   #Parameter: data, rank, disp, win
             MPI.Win_fence(0, win)
         end
-        toc = MPI.Wtime()
     else
         for _ in 1:iters
             MPI.Win_fence(0, win)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -89,4 +89,20 @@ end
             """
         @test !success(mpiexec(cmd->ignorestatus(`$(cmd) -np 3 $(julia) --project -e $(script)`)))
     end
+
+    @testset "OSU - One sided" begin
+        # OSU One sided benchmarks require exactly 2 processes
+        script = """
+            using MPIBenchmarks
+            const verbose = false
+            mktemp() do filename, io
+                benchmark(OSUPutLatency())
+                benchmark(OSUPutLatency(; synchronization_option = "fence") )
+                benchmark(OSUGetLatency())
+                benchmark(OSUGetLatency(; synchronization_option = "fence") )
+            end
+            """
+        @test success(mpiexec(cmd->run(`$(cmd) -np 2 $(julia) --project -e $(script)`)))
+    end
+
 end


### PR DESCRIPTION
These one-sided benchmarks require exactly two ranks. The default window synchronization is MPI.Win_lock. We can change the window synchronization to MPI.Win_fence by setting the parameter of OSUGetLatency(; synchronization_option = "fence").

mpiexecjl -n 2 julia --project -e 'using MPIBenchmarks; benchmark(OSUPutLatency())'

> Running benchmark OSU Put Latency with type Float32 on 2 MPI ranks with window synchronization: lock
> 
> size (bytes),iterations,time (seconds)
> 0,262144,0.4127996362512931
> 4,262144,0.7047183316899464
> 8,262144,0.7146818461478688
> 16,262144,0.7808421287336387
> 32,262144,0.7772323442623019
> 64,262144,0.7960952643770725
> 128,262144,0.8018741937121376
> 256,262144,0.8307497409987263
> 512,262144,0.8501665433868766
> 1024,262144,0.9040168151841499
> 2048,131072,1.0597614163998514
> 4096,65536,1.3070457498542964
> 8192,32768,1.2989548849873245
> 16384,16384,2.59112857747823
> 32768,8192,4.12165536545217
> 65536,4096,7.199530955404043
> 131072,2048,12.545846402645111
> 262144,1024,21.67397178709507
> 524288,512,36.543700844049454
> 1048576,256,107.30139911174774

----------------------------------------

├ mpiexecjl -n 2 julia --project -e 'using MPIBenchmarks; benchmark(OSUPutLatency(; synchronization_option = "fence"))'

> Running benchmark OSU Put Latency with type Float32 on 2 MPI ranks with window synchronization: fence
> 
> size (bytes),iterations,time (seconds)
> 0,262144,1.8094606275553815
> 4,262144,2.0948673409293406
> 8,262144,2.1043251763330773
> 16,262144,2.109244633174967
> 32,262144,2.2035719666746445
> 64,262144,2.2693757273373194
> 128,262144,2.271567609568592
> 256,262144,2.12416398426285
> 512,262144,2.1238183762761764
> 1024,262144,2.2200702005648054
> 2048,131072,2.297674654982984
> 4096,65536,2.683598722796887
> 8192,32768,3.21494007948786
> 16384,16384,4.020315827801824
> 32768,8192,5.075300578027964
> 65536,4096,11.463940609246492
> 131072,2048,21.06290776282549
> 262144,1024,42.62127913534641
> 524288,512,109.60642248392105
> 1048576,256,318.84387135505676

----------------------------------------

├ mpiexecjl -n 2 julia --project -e 'using MPIBenchmarks; benchmark(OSUGetLatency())'

```
> Running benchmark OSU Get Latency with type Float32 on 2 MPI ranks with window synchronization: lock
> 
> size (bytes),iterations,time (seconds)
> 0,262144,0.40867871575756
> 4,262144,0.7469416232197545
> 8,262144,0.7774142432026565
> 16,262144,0.6824739102739841
> 32,262144,0.7015305527602322
> 64,262144,0.729616658645682
> 128,262144,0.7536673365393654
> 256,262144,0.7903618097770959
> 512,262144,0.7806038411217742
> 1024,262144,0.831908437248785
> 2048,131072,0.9554587450111285
> 4096,65536,1.2340606190264225
> 8192,32768,1.7921629478223622
> 16384,16384,2.7989590307697654
> 32768,8192,4.171539330855012
> 65536,4096,7.231137715280056
> 131072,2048,12.863660231232643
> 262144,1024,24.079112336039543
> 524288,512,40.96515476703644
> 1048576,256,122.11687862873077
> ------------------------------------
```

├ mpiexecjl -n 2 julia --project -e 'using MPIBenchmarks; benchmark(OSUGetLatency(; synchronization_option = "fence"))'

> Running benchmark OSU Get Latency with type Float32 on 2 MPI ranks with window synchronization: fence
> 
> size (bytes),iterations,time (seconds)
> 0,262144,1.8871678548748605
> 4,262144,2.379967554588802
> 8,262144,2.3787006284692325
> 16,262144,2.3218381102196872
> 32,262144,2.2528383851749822
> 64,262144,2.4219225451815873
> 128,262144,2.521945134503767
> 256,262144,2.4053715605987236
> 512,262144,2.6832849471247755
> 1024,262144,2.674258212209679
> 2048,131072,2.6364341465523466
> 4096,65536,3.181292413501069
> 8192,32768,3.361135895829648
> 16384,16384,4.418121534399688
> 32768,8192,5.797541234642267
> 65536,4096,11.398748029023409
> 131072,2048,28.794165700674057
> 262144,1024,43.94561983644962
> 524288,512,105.34701868891716
> 1048576,256,362.10380494594574