### PR TITLE
Cache avoidance experiment

### DIFF
--- a/src/MPIBenchmarks.jl
+++ b/src/MPIBenchmarks.jl
@@ -11,6 +11,7 @@ struct Configuration{T}
     iters::Function
     stdout::IO
     filename::Union{String,Nothing}
+    off_cache::Union{Int64,Nothing}
 end
 
 function iterations(::Type{T}, s::Int) where {T}
@@ -24,6 +25,7 @@ function Configuration(T::Type;
                        verbose::Bool=true,
                        filename::Union{String,Nothing}=nothing,
                        iterations::Function=iterations,
+                       off_cache::Union{Int64,Nothing}=0,
                        )
     ispow2(max_size) || throw(ArgumentError("Maximum size must be a power of 2, found $(max_size)"))
     isprimitivetype(T) || throw(ArgumentError("Type $(T) is not a primitive type"))
@@ -38,7 +40,7 @@ function Configuration(T::Type;
     if isnothing(stdout)
         stdout = verbose ? Base.stdout : Base.devnull
     end
-    return Configuration(T, lengths, iterations, stdout, filename)
+    return Configuration(T, lengths, iterations, stdout, filename, off_cache)
 end
 
 """

--- a/src/imb_allreduce.jl
+++ b/src/imb_allreduce.jl
@@ -16,15 +16,10 @@ function IMBAllreduce(T::Type=Float32;
 end
 
 function imb_allreduce(T::Type, bufsize::Int, iters::Int, comm::MPI.Comm, off_cache::Int64)
-    # If the "off_cache" is equal to zero then there will be no cache avoidance, and only single array of send_buffer & recv_buffer will be created.
-    cache_size =  off_cache # Required in Bytes
-    
-    # To avoid integer division error when bufsize is equal to zero
+    cache_size =  off_cache # Required in Bytes    
     num_buffers = max(1, 2 * cache_size ÷ max(1, (sizeof(T) * bufsize)))
-    
     send_buffer = [zeros(T, bufsize) for _ in 1:num_buffers]
     recv_buffer = [zeros(T, bufsize) for _ in 1:num_buffers]
-
     timer = 0.0
     MPI.Barrier(comm)
     for i in 1:iters

--- a/src/imb_allreduce.jl
+++ b/src/imb_allreduce.jl
@@ -15,14 +15,25 @@ function IMBAllreduce(T::Type=Float32;
     )
 end
 
-function imb_allreduce(T::Type, bufsize::Int, iters::Int, comm::MPI.Comm)
-    send_buffer = zeros(T, bufsize)
-    recv_buffer = zeros(T, bufsize)
+function imb_allreduce(T::Type, bufsize::Int, iters::Int, comm::MPI.Comm, off_cache::Int64)
+    # If the "off_cache" is equal to zero then there will be no cache avoidance, and only single array of send_buffer & recv_buffer will be created.
+    cache_size =  off_cache # Required in Bytes
+    
+    # To avoid integer division error when bufsize is equal to zero
+    if bufsize == 0
+        num_buffers = max(1, 2 * cache_size)
+    else
+        num_buffers = max(1, 2 * cache_size ÷ (sizeof(T) * bufsize))
+    end
+    
+    send_buffer = [zeros(T, bufsize) for _ in 1:num_buffers]
+    recv_buffer = [zeros(T, bufsize) for _ in 1:num_buffers]
+
     timer = 0.0
     MPI.Barrier(comm)
     for i in 1:iters
         tic = MPI.Wtime()
-        MPI.Allreduce!(send_buffer, recv_buffer, +, comm)
+        MPI.Allreduce!(@inbounds(send_buffer[mod1(i, num_buffers)]), @inbounds(recv_buffer[mod1(i, num_buffers)]), +, comm)
         toc = MPI.Wtime()
         timer += toc - tic
     end

--- a/src/imb_allreduce.jl
+++ b/src/imb_allreduce.jl
@@ -20,11 +20,7 @@ function imb_allreduce(T::Type, bufsize::Int, iters::Int, comm::MPI.Comm, off_ca
     cache_size =  off_cache # Required in Bytes
     
     # To avoid integer division error when bufsize is equal to zero
-    if bufsize == 0
-        num_buffers = max(1, 2 * cache_size)
-    else
-        num_buffers = max(1, 2 * cache_size ÷ (sizeof(T) * bufsize))
-    end
+    num_buffers = max(1, 2 * cache_size ÷ max(1, (sizeof(T) * bufsize)))
     
     send_buffer = [zeros(T, bufsize) for _ in 1:num_buffers]
     recv_buffer = [zeros(T, bufsize) for _ in 1:num_buffers]

--- a/src/imb_alltoall.jl
+++ b/src/imb_alltoall.jl
@@ -16,21 +16,11 @@ function IMBAlltoall(T::Type=UInt8;
 end
 
 function imb_alltoall(T::Type, bufsize::Int, iters::Int, comm::MPI.Comm, off_cache::Int64 )
-    # If the "off_cache" is equal to zero then there will be no cache avoidance, and only single array of send_buffer & recv_buffer will be created.
     cache_size =  off_cache # Required in Bytes
-    
-    # To avoid integer division error when bufsize is equal to zero
-    if bufsize == 0
-        num_buffers = max(1, 2 * cache_size)
-    else
-        num_buffers = max(1, 2 * cache_size ÷ (sizeof(T) * bufsize))
-    end
-    
-    rank = MPI.Comm_rank(comm)
+    num_buffers = max(1, 2 * cache_size ÷ max(1, (sizeof(T) * bufsize)))    
     nranks = MPI.Comm_size(comm)
     buffer = [zeros(T, bufsize * nranks) for _ in 1:num_buffers]
     timer = 0.0
-
     MPI.Barrier(comm)
     for i in 1:iters
         tic = MPI.Wtime()

--- a/src/imb_alltoall.jl
+++ b/src/imb_alltoall.jl
@@ -26,9 +26,9 @@ function imb_alltoall(T::Type, bufsize::Int, iters::Int, comm::MPI.Comm, off_cac
         num_buffers = max(1, 2 * cache_size ÷ (sizeof(T) * bufsize))
     end
     
-    buffer = [zeros(T, bufsize * nranks) for _ in 1:num_buffers]
     rank = MPI.Comm_rank(comm)
     nranks = MPI.Comm_size(comm)
+    buffer = [zeros(T, bufsize * nranks) for _ in 1:num_buffers]
     timer = 0.0
 
     MPI.Barrier(comm)

--- a/src/imb_alltoall.jl
+++ b/src/imb_alltoall.jl
@@ -15,16 +15,26 @@ function IMBAlltoall(T::Type=UInt8;
     )
 end
 
-function imb_alltoall(T::Type, bufsize::Int, iters::Int, comm::MPI.Comm)
+function imb_alltoall(T::Type, bufsize::Int, iters::Int, comm::MPI.Comm, off_cache::Int64 )
+    # If the "off_cache" is equal to zero then there will be no cache avoidance, and only single array of send_buffer & recv_buffer will be created.
+    cache_size =  off_cache # Required in Bytes
+    
+    # To avoid integer division error when bufsize is equal to zero
+    if bufsize == 0
+        num_buffers = max(1, 2 * cache_size)
+    else
+        num_buffers = max(1, 2 * cache_size ÷ (sizeof(T) * bufsize))
+    end
+    
+    buffer = [zeros(T, bufsize * nranks) for _ in 1:num_buffers]
     rank = MPI.Comm_rank(comm)
     nranks = MPI.Comm_size(comm)
-    buffer = zeros(T, bufsize * nranks)
-    root = 0
     timer = 0.0
+
     MPI.Barrier(comm)
     for i in 1:iters
         tic = MPI.Wtime()
-        MPI.Alltoall!(UBuffer(buffer, Cint(bufsize), Cint(nranks), MPI.Datatype(T)), comm)
+        MPI.Alltoall!(UBuffer(@inbounds(buffer[mod1(i, num_buffers)]), Cint(bufsize), Cint(nranks), MPI.Datatype(T)), comm)
         toc = MPI.Wtime()
         timer += toc - tic
     end

--- a/src/imb_collective.jl
+++ b/src/imb_collective.jl
@@ -8,7 +8,7 @@ function run_imb_collective(benchmark::MPIBenchmark, func::Function, conf::Confi
     nranks = MPI.Comm_size(comm)
 
     # Warmup
-    func(conf.T, 1, 10, comm)
+    func(conf.T, 1, 10, comm, conf.off_cache)
 
     if iszero(rank)
         print_header(io) = println(io, "size (bytes),iteratons,min_time (seconds),max_time (seconds),avg_time (seconds)")
@@ -28,7 +28,7 @@ function run_imb_collective(benchmark::MPIBenchmark, func::Function, conf::Confi
         size = 1 << s
         iters = conf.iters(conf.T, s)
         # Measure time on current rank
-        time = func(conf.T, size, iters, comm)
+        time = func(conf.T, size, iters, comm, conf.off_cache)
 
         if !iszero(rank)
             # If we aren't on rank 0, send to it our time

--- a/src/imb_gatherv.jl
+++ b/src/imb_gatherv.jl
@@ -26,10 +26,10 @@ function imb_gatherv(T::Type, bufsize::Int, iters::Int, comm::MPI.Comm)
         num_buffers = max(1, 2 * cache_size ÷ (sizeof(T) * bufsize))
     end
     
-    send_buffer = [zeros(T, bufsize) for _ in 1:num_buffers]
-    recv_buffer = [zeros(T, bufsize * nranks) for _ in 1:num_buffers]
     rank = MPI.Comm_rank(comm)
     nranks = MPI.Comm_size(comm)
+    send_buffer = [zeros(T, bufsize) for _ in 1:num_buffers]
+    recv_buffer = [zeros(T, bufsize * nranks) for _ in 1:num_buffers]
     
     counts = [bufsize for _ in 1:nranks]
     root = 0

--- a/src/imb_gatherv.jl
+++ b/src/imb_gatherv.jl
@@ -15,7 +15,7 @@ function IMBGatherv(T::Type=UInt8;
     )
 end
 
-function imb_gatherv(T::Type, bufsize::Int, iters::Int, comm::MPI.Comm)
+function imb_gatherv(T::Type, bufsize::Int, iters::Int, comm::MPI.Comm, off_cache::Int64)
     # If the "off_cache" is equal to zero then there will be no cache avoidance, and only single array of send_buffer & recv_buffer will be created.
     cache_size =  off_cache # Required in Bytes
     

--- a/src/imb_gatherv.jl
+++ b/src/imb_gatherv.jl
@@ -16,10 +16,21 @@ function IMBGatherv(T::Type=UInt8;
 end
 
 function imb_gatherv(T::Type, bufsize::Int, iters::Int, comm::MPI.Comm)
+    # If the "off_cache" is equal to zero then there will be no cache avoidance, and only single array of send_buffer & recv_buffer will be created.
+    cache_size =  off_cache # Required in Bytes
+    
+    # To avoid integer division error when bufsize is equal to zero
+    if bufsize == 0
+        num_buffers = max(1, 2 * cache_size)
+    else
+        num_buffers = max(1, 2 * cache_size ÷ (sizeof(T) * bufsize))
+    end
+    
+    send_buffer = [zeros(T, bufsize) for _ in 1:num_buffers]
+    recv_buffer = [zeros(T, bufsize * nranks) for _ in 1:num_buffers]
     rank = MPI.Comm_rank(comm)
     nranks = MPI.Comm_size(comm)
-    send_buffer = zeros(T, bufsize)
-    recv_buffer = zeros(T, bufsize * nranks)
+    
     counts = [bufsize for _ in 1:nranks]
     root = 0
     timer = 0.0
@@ -27,9 +38,9 @@ function imb_gatherv(T::Type, bufsize::Int, iters::Int, comm::MPI.Comm)
     for i in 1:iters
         tic = MPI.Wtime()
         if rank == root
-            MPI.Gatherv!(MPI.IN_PLACE, VBuffer(recv_buffer, counts), comm; root)
+            MPI.Gatherv!(MPI.IN_PLACE, VBuffer(@inbounds(recv_buffer[mod1(i, num_buffers)]), counts), comm; root)
         else
-            MPI.Gatherv!(send_buffer, nothing, comm; root)
+            MPI.Gatherv!(@inbounds(send_buffer[mod1(i, num_buffers)]), nothing, comm; root)
         end
         toc = MPI.Wtime()
         timer += toc - tic

--- a/src/imb_reduce.jl
+++ b/src/imb_reduce.jl
@@ -16,10 +16,17 @@ function IMBReduce(T::Type=Float32;
 end
 
 function imb_reduce(T::Type, bufsize::Int, iters::Int, comm::MPI.Comm)
-    cache_size = 2 ^ 16 # Assume cache size of 64 KiB
-    # To avoid hitting the cache, create buffers which are arrays of arrays of size
-    # `bufsize` so that they exceed the cache size
-    num_buffers = max(1, 2 * cache_size ÷ (sizeof(T) * bufsize))
+    # for Noctua 1, L3 cache is 27.5 MiB
+    # l3: 27.5*1024*1024 = 28835840
+    cache_size =  28835840 
+    
+    # To avoid integer division error when bufsize is equal to zero
+    if bufsize == 0
+        num_buffers = max(1, 2 * cache_size)
+    else
+        num_buffers = max(1, 2 * cache_size ÷ (sizeof(T) * bufsize))
+    end
+    
     send_buffer = [zeros(T, bufsize) for _ in 1:num_buffers]
     recv_buffer = [zeros(T, bufsize) for _ in 1:num_buffers]
     timer = 0.0

--- a/src/imb_reduce.jl
+++ b/src/imb_reduce.jl
@@ -16,19 +16,8 @@ function IMBReduce(T::Type=Float32;
 end
 
 function imb_reduce(T::Type, bufsize::Int, iters::Int, comm::MPI.Comm, off_cache::Int64)
-    # for Noctua 1, L3 cache is 27.5 MiB
-    # l3: 27.5*1024*1024 = 28835840 Bytes
-
-    # If the "off_cache" is equal to zero then there will be no cache avoidance, and only single array of send_buffer & recv_buffer will be created.
     cache_size =  off_cache # Required in Bytes
-    
-    # To avoid integer division error when bufsize is equal to zero
-    if bufsize == 0
-        num_buffers = max(1, 2 * cache_size)
-    else
-        num_buffers = max(1, 2 * cache_size ÷ (sizeof(T) * bufsize))
-    end
-    
+    num_buffers = max(1, 2 * cache_size ÷ max(1, (sizeof(T) * bufsize)))
     send_buffer = [zeros(T, bufsize) for _ in 1:num_buffers]
     recv_buffer = [zeros(T, bufsize) for _ in 1:num_buffers]
     timer = 0.0

--- a/src/imb_reduce.jl
+++ b/src/imb_reduce.jl
@@ -15,10 +15,12 @@ function IMBReduce(T::Type=Float32;
     )
 end
 
-function imb_reduce(T::Type, bufsize::Int, iters::Int, comm::MPI.Comm)
+function imb_reduce(T::Type, bufsize::Int, iters::Int, comm::MPI.Comm, off_cache::Int64)
     # for Noctua 1, L3 cache is 27.5 MiB
-    # l3: 27.5*1024*1024 = 28835840
-    cache_size =  28835840 
+    # l3: 27.5*1024*1024 = 28835840 Bytes
+
+    # If the "off_cache" is equal to zero then there will be no cache avoidance, and only single array of send_buffer & recv_buffer will be created.
+    cache_size =  off_cache # Required in Bytes
     
     # To avoid integer division error when bufsize is equal to zero
     if bufsize == 0

--- a/src/osu_allreduce.jl
+++ b/src/osu_allreduce.jl
@@ -16,20 +16,10 @@ function OSUAllreduce(T::Type=Float32;
 end
 
 function osu_allreduce(T::Type, bufsize::Int, iters::Int, comm::MPI.Comm, off_cache::Int64)
-
-     # If the "off_cache" is equal to zero then there will be no cache avoidance, and only single array of send_buffer & recv_buffer will be created.
     cache_size =  off_cache # Required in Bytes
-    
-    # To avoid integer division error when bufsize is equal to zero
-    if bufsize == 0
-        num_buffers = max(1, 2 * cache_size)
-    else
-        num_buffers = max(1, 2 * cache_size ÷ (sizeof(T) * bufsize))
-    end
-    
+    num_buffers = max(1, 2 * cache_size ÷ max(1, (sizeof(T) * bufsize)))
     send_buffer = [ones(T, bufsize) for _ in 1:num_buffers]
     recv_buffer = [zeros(T, bufsize) for _ in 1:num_buffers]
-
     timer = 0.0
     MPI.Barrier(comm)
     for i in 1:iters

--- a/src/osu_allreduce.jl
+++ b/src/osu_allreduce.jl
@@ -15,14 +15,26 @@ function OSUAllreduce(T::Type=Float32;
     )
 end
 
-function osu_allreduce(T::Type, bufsize::Int, iters::Int, comm::MPI.Comm)
-    send_buffer = ones(T, bufsize)
-    recv_buffer = zeros(T, bufsize)
+function osu_allreduce(T::Type, bufsize::Int, iters::Int, comm::MPI.Comm, off_cache::Int64)
+
+     # If the "off_cache" is equal to zero then there will be no cache avoidance, and only single array of send_buffer & recv_buffer will be created.
+    cache_size =  off_cache # Required in Bytes
+    
+    # To avoid integer division error when bufsize is equal to zero
+    if bufsize == 0
+        num_buffers = max(1, 2 * cache_size)
+    else
+        num_buffers = max(1, 2 * cache_size ÷ (sizeof(T) * bufsize))
+    end
+    
+    send_buffer = [ones(T, bufsize) for _ in 1:num_buffers]
+    recv_buffer = [zeros(T, bufsize) for _ in 1:num_buffers]
+
     timer = 0.0
     MPI.Barrier(comm)
     for i in 1:iters
         tic = MPI.Wtime()
-        MPI.Allreduce!(send_buffer, recv_buffer, +, comm)
+        MPI.Allreduce!(@inbounds(send_buffer[mod1(i, num_buffers)]), @inbounds(recv_buffer[mod1(i, num_buffers)]), +, comm)
         toc = MPI.Wtime()
         timer += toc - tic
     end

--- a/src/osu_alltoall.jl
+++ b/src/osu_alltoall.jl
@@ -16,20 +16,11 @@ function OSUAlltoall(T::Type=UInt8;
 end
 
 function osu_alltoall(T::Type, bufsize::Int, iters::Int, comm::MPI.Comm, off_cache::Int64)
-     # If the "off_cache" is equal to zero then there will be no cache avoidance, and only single array of send_buffer & recv_buffer will be created.
     cache_size =  off_cache # Required in Bytes
-    
-    # To avoid integer division error when bufsize is equal to zero
-    if bufsize == 0
-        num_buffers = max(1, 2 * cache_size)
-    else
-        num_buffers = max(1, 2 * cache_size ÷ (sizeof(T) * bufsize))
-    end
-    
+    num_buffers = max(1, 2 * cache_size ÷ max(1, (sizeof(T) * bufsize)))    
     nranks = MPI.Comm_size(comm)
     send_buffer = [ones(T, bufsize * nranks) for _ in 1:num_buffers]
     recv_buffer = [zeros(T, bufsize * nranks) for _ in 1:num_buffers]
-
     timer = 0.0
     MPI.Barrier(comm)
     for i in 1:iters

--- a/src/osu_alltoall.jl
+++ b/src/osu_alltoall.jl
@@ -26,9 +26,10 @@ function osu_alltoall(T::Type, bufsize::Int, iters::Int, comm::MPI.Comm, off_cac
         num_buffers = max(1, 2 * cache_size ÷ (sizeof(T) * bufsize))
     end
     
+    nranks = MPI.Comm_size(comm)
     send_buffer = [ones(T, bufsize * nranks) for _ in 1:num_buffers]
     recv_buffer = [zeros(T, bufsize * nranks) for _ in 1:num_buffers]
-    nranks = MPI.Comm_size(comm)
+
     timer = 0.0
     MPI.Barrier(comm)
     for i in 1:iters

--- a/src/osu_alltoall.jl
+++ b/src/osu_alltoall.jl
@@ -15,19 +15,27 @@ function OSUAlltoall(T::Type=UInt8;
     )
 end
 
-function osu_alltoall(T::Type, bufsize::Int, iters::Int, comm::MPI.Comm)
-    rank = MPI.Comm_rank(comm)
+function osu_alltoall(T::Type, bufsize::Int, iters::Int, comm::MPI.Comm, off_cache::Int64)
+     # If the "off_cache" is equal to zero then there will be no cache avoidance, and only single array of send_buffer & recv_buffer will be created.
+    cache_size =  off_cache # Required in Bytes
+    
+    # To avoid integer division error when bufsize is equal to zero
+    if bufsize == 0
+        num_buffers = max(1, 2 * cache_size)
+    else
+        num_buffers = max(1, 2 * cache_size ÷ (sizeof(T) * bufsize))
+    end
+    
+    send_buffer = [ones(T, bufsize * nranks) for _ in 1:num_buffers]
+    recv_buffer = [zeros(T, bufsize * nranks) for _ in 1:num_buffers]
     nranks = MPI.Comm_size(comm)
-    send_buffer = ones(T, bufsize * nranks)
-    recv_buffer = zeros(T, bufsize * nranks)
-    root = 0
     timer = 0.0
     MPI.Barrier(comm)
     for i in 1:iters
         tic = MPI.Wtime()
         MPI.Alltoall!(
-            UBuffer(send_buffer, Cint(bufsize), Cint(nranks), MPI.Datatype(T)),
-            UBuffer(recv_buffer, Cint(bufsize), Cint(nranks), MPI.Datatype(T)),
+            UBuffer(@inbounds(send_buffer[mod1(i, num_buffers)]), Cint(bufsize), Cint(nranks), MPI.Datatype(T)),
+            UBuffer(@inbounds(recv_buffer[mod1(i, num_buffers)]), Cint(bufsize), Cint(nranks), MPI.Datatype(T)),
             comm)
         toc = MPI.Wtime()
         timer += toc - tic

--- a/src/osu_reduce.jl
+++ b/src/osu_reduce.jl
@@ -15,10 +15,11 @@ function OSUReduce(T::Type=Float32;
     )
 end
 
-function osu_reduce(T::Type, bufsize::Int, iters::Int, comm::MPI.Comm)
+function osu_reduce(T::Type, bufsize::Int, iters::Int, comm::MPI.Comm, off_cache::Int64 )
     # for Noctua 1, L3 cache is 27.5 MiB
     # l3: 27.5*1024*1024 = 28835840
-    cache_size =  28835840 
+    # If the "off_cache" is equal to zero then there will be no cache avoidance, and only single array of send_buffer & recv_buffer will be created.
+    cache_size =  off_cache # Required in Bytes
     
     # To avoid integer division error when bufsize is equal to zero
     if bufsize == 0

--- a/src/osu_reduce.jl
+++ b/src/osu_reduce.jl
@@ -18,9 +18,8 @@ end
 function osu_reduce(T::Type, bufsize::Int, iters::Int, comm::MPI.Comm)
     # for Noctua 1, L3 cache is 27.5 MiB
     # l3: 27.5*1024*1024 = 28835840
-    #cache_size =  28835840 
-    cache_size = 6291456
-
+    cache_size =  28835840 
+    
     # To avoid integer division error when bufsize is equal to zero
     if bufsize == 0
         num_buffers = max(1, 2 * cache_size)

--- a/src/osu_reduce.jl
+++ b/src/osu_reduce.jl
@@ -16,20 +16,10 @@ function OSUReduce(T::Type=Float32;
 end
 
 function osu_reduce(T::Type, bufsize::Int, iters::Int, comm::MPI.Comm, off_cache::Int64 )
-    # for Noctua 1, L3 cache is 27.5 MiB
-    # l3: 27.5*1024*1024 = 28835840
-    # If the "off_cache" is equal to zero then there will be no cache avoidance, and only single array of send_buffer & recv_buffer will be created.
     cache_size =  off_cache # Required in Bytes
-    
-    # To avoid integer division error when bufsize is equal to zero
-    if bufsize == 0
-        num_buffers = max(1, 2 * cache_size)
-    else
-        num_buffers = max(1, 2 * cache_size ÷ (sizeof(T) * bufsize))
-    end
+    num_buffers = max(1, 2 * cache_size ÷ max(1, (sizeof(T) * bufsize)))
     send_buffer = [zeros(T, bufsize) for _ in 1:num_buffers]
     recv_buffer = [ones(T, bufsize) for _ in 1:num_buffers]
-
     timer = 0.0
     MPI.Barrier(comm)
     for i in 1:iters

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -40,6 +40,7 @@ end
             const verbose = false
             mktemp() do filename, io
                 benchmark(IMBAllreduce(; verbose, filename))
+                benchmark(IMBAllreduce(; verbose, filename, off_cache=28835))
                 benchmark(IMBAlltoall(; verbose, filename, max_size=1<<16))
                 benchmark(IMBGatherv(; verbose, filename))
                 benchmark(IMBReduce(; verbose, filename))


### PR DESCRIPTION
Hi, 

In order to test the cache avoidance I ran 'osu_reduce.jl' on Noctua 1 multiple times but it seems that this strategy is not working.
First I try by setting the buffer size greater than the L1 Cache, then by setting the buffer size greater than L3 Cache. The results below are generated by setting the send_buffer greater than L3 Cache of Noctua 1. Also, I run it on one Node with 4 MPI ranks.

The graphs below show that when we run it with cache avoidance, then it is faster.


| Attempt | #1    | -    |
| :---:   | :---: | :---: |
| Run 1 | ![image](https://user-images.githubusercontent.com/9871507/202767059-0e7044c9-db80-47b0-82aa-beaaacdb0db5.png)
   | -|
| Run 2| ![image](https://user-images.githubusercontent.com/9871507/202767108-c02e22e8-7400-453b-875b-e48a6887f7a5.png)
   | -|
| Run 3 | ![image](https://user-images.githubusercontent.com/9871507/202767163-eb836b50-4202-4097-b8ac-082bb20d6ace.png)
   | -|




I also tried other strategies to avoid cache avoidance for example using random numbers. Or setting the new send and receive buffer in each iteration but all these strategies also did not work. Do have any other idea how to solve this problem?