### PR TITLE
OSU Bandwidth

### DIFF
--- a/src/MPIBenchmarks.jl
+++ b/src/MPIBenchmarks.jl
@@ -12,6 +12,7 @@ struct Configuration{T}
     stdout::IO
     filename::Union{String,Nothing}
     synchronization_option::Union{String,Nothing}
+    window_size::Union{Int64,Nothing}
 end
 
 function iterations(::Type{T}, s::Int) where {T}
@@ -26,6 +27,7 @@ function Configuration(T::Type;
                        filename::Union{String,Nothing}=nothing,
                        iterations::Function=iterations,
                        synchronization_option::Union{String,Nothing}="lock",
+                       window_size::Union{Int64,Nothing}=64
                        )
     ispow2(max_size) || throw(ArgumentError("Maximum size must be a power of 2, found $(max_size)"))
     isprimitivetype(T) || throw(ArgumentError("Type $(T) is not a primitive type"))
@@ -40,7 +42,7 @@ function Configuration(T::Type;
     if isnothing(stdout)
         stdout = verbose ? Base.stdout : Base.devnull
     end
-    return Configuration(T, lengths, iterations, stdout, filename, synchronization_option)
+    return Configuration(T, lengths, iterations, stdout, filename, synchronization_option, window_size)
 end
 
 """

--- a/src/osu_bw.jl
+++ b/src/osu_bw.jl
@@ -40,11 +40,10 @@ function osu_bw(T::Type, bufsize::Int, iters::Int, comm::MPI.Comm, window_size::
                 recv_list[k] = MPI.Irecv!(recv_buffer, comm; source=0, tag=100)
             end
             MPI.Waitall(recv_list)
-            MPI.send(send_buffer, comm; dest=0, tag=101)
+            MPI.send(send_buffer, comm; dest=root, tag=101)
         end
     end
-    avgtime = timer / iters
-    return avgtime
+    return timer / iters
 end
 
 benchmark(bench::OSUBw) = run_osu_p2p(bench, osu_bw, bench.conf; cal_bandwidth=true)

--- a/src/osu_bw.jl
+++ b/src/osu_bw.jl
@@ -1,0 +1,50 @@
+export OSUBw
+
+struct OSUBw <: MPIBenchmark
+    conf::Configuration
+    name::String
+end
+
+function OSUBw(T::Type=Float32;
+                   filename::Union{String,Nothing}="julia_osu_bw.csv",
+                   kwargs...,
+                   )
+    return OSUBw(
+        Configuration(T; filename, max_size=2 ^ 20, kwargs...),
+        "OSU Bandwidth",
+    )
+end
+
+function osu_bw(T::Type, bufsize::Int, iters::Int, comm::MPI.Comm, window_size::Int)
+    send_buffer = zeros(T, bufsize)
+    recv_buffer = ones(T, bufsize)
+    timer = 0.0
+    rank = MPI.Comm_rank(comm)
+    root = 0
+    send_list = Array{MPI.Request}(undef, window_size)
+    recv_list = Array{MPI.Request}(undef, window_size)
+
+    MPI.Barrier(comm)
+    for _ in 1:iters
+        if  rank == root
+            tic = MPI.Wtime()
+            for j in 1:window_size
+                send_list[j] = MPI.Isend(send_buffer, comm; dest=1, tag=100)
+            end
+            MPI.Waitall(send_list)
+            MPI.recv(comm; source=1, tag=101)
+            toc = MPI.Wtime()
+            timer += toc - tic
+        else
+            for k in 1:window_size
+                recv_list[k] = MPI.Irecv!(recv_buffer, comm; source=0, tag=100)
+            end
+            MPI.Waitall(recv_list)
+            MPI.send(send_buffer, comm; dest=0, tag=101)
+        end
+    end
+    avgtime = timer / iters
+    return avgtime
+end
+
+benchmark(bench::OSUBw) = run_osu_p2p(bench, osu_bw, bench.conf; cal_bandwidth=true)

--- a/src/osu_latency.jl
+++ b/src/osu_latency.jl
@@ -15,7 +15,7 @@ function OSULatency(T::Type=UInt8;
     )
 end
 
-function osu_latency(T::Type, bufsize::Int, iters::Int, comm::MPI.Comm)
+function osu_latency(T::Type, bufsize::Int, iters::Int, comm::MPI.Comm, window_size::Int)
     rank = MPI.Comm_rank(comm)
     send_buffer = rand(T, bufsize)
     recv_buffer = rand(T, bufsize)

--- a/src/osu_p2p.jl
+++ b/src/osu_p2p.jl
@@ -43,12 +43,11 @@ function run_osu_p2p(benchmark::MPIBenchmark, func::Function, conf::Configuratio
             bytes = size * sizeof(conf.T)
             latency = time / 2
 
-            if cal_bandwidth
+            result = if cal_bandwidth
                 tmp_total = bytes / 1e+6 * iters * conf.window_size
-                bandwidth = tmp_total / time
-                result = bandwidth
+                tmp_total / time
             else
-                result = latency
+                latency
             end
             # Print out our results
                 print_result(conf.stdout, bytes, iters, latency)

--- a/src/osu_p2p.jl
+++ b/src/osu_p2p.jl
@@ -1,5 +1,5 @@
 function run_osu_p2p(benchmark::MPIBenchmark, func::Function, conf::Configuration;
-                     divide_latency_by_two::Bool=false)
+                     divide_latency_by_two::Bool=false, cal_bandwidth::Bool=false)
     MPI.Init()
 
     comm = MPI.COMM_WORLD
@@ -17,12 +17,11 @@ function run_osu_p2p(benchmark::MPIBenchmark, func::Function, conf::Configuratio
     end
 
     # Warmup
-    func(conf.T, 1, 10, comm)
+    func(conf.T, 1, 10, comm, conf.window_size)
 
     if iszero(rank)
-        print_header(io) = println(io, "size (bytes),iterations,latency (seconds)")
-        print_timings(io, bytes, iters, latency) = println(io, bytes, ",", iters, ",", latency)
-
+        print_header(io) = cal_bandwidth == true ? println(io, "size (bytes),iterations,bandwidth (MB/s)") :  println(io, "size (bytes),iterations,latency (seconds)")
+        print_result(io, bytes, iters, result) = println(io, bytes, ",", iters, ",", result)
         println(conf.stdout, "----------------------------------------")
         println(conf.stdout, "Running benchmark ", benchmark.name, " with type ", conf.T, " on ", nranks, " MPI ranks")
         println(conf.stdout)
@@ -37,17 +36,24 @@ function run_osu_p2p(benchmark::MPIBenchmark, func::Function, conf::Configuratio
         size = 1 << s
         iters = conf.iters(conf.T, s)
         # Measure time on current rank
-        time = func(conf.T, size, iters, comm)
+        time = func(conf.T, size, iters, comm, conf.window_size)
 
         if iszero(rank)
             # Number of bytes trasmitted
             bytes = size * sizeof(conf.T)
             latency = time / 2
 
+            if cal_bandwidth
+                tmp_total = bytes / 1e+6 * iters * conf.window_size
+                bandwidth = tmp_total / time
+                result = bandwidth
+            else
+                result = latency
+            end
             # Print out our results
-            print_timings(conf.stdout, bytes, iters, latency)
-            if !isnothing(conf.filename)
-                print_timings(file, bytes, iters, latency)
+                print_result(conf.stdout, bytes, iters, latency)
+                if !isnothing(conf.filename)
+                    print_result(file, bytes, iters, result)
             end
         end
     end
@@ -63,3 +69,5 @@ function run_osu_p2p(benchmark::MPIBenchmark, func::Function, conf::Configuratio
 end
 
 include("osu_latency.jl")
+include("osu_bw.jl")
+

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -91,6 +91,7 @@ end
             const verbose = false
             mktemp() do filename, io
                 benchmark(OSULatency(; verbose, filename))
+                benchmark(OSUBw(; verbose, filename, window_size=64))
             end
             """
         @test !success(mpiexec(cmd->ignorestatus(`$(cmd) -np 3 $(julia) --project -e $(script)`)))


### PR DESCRIPTION
mpiexec -n 2 julia --project -e 'using MPIBenchmarks; benchmark(OSUBw(; window_size=64))'

----------------------------------------
Running benchmark OSU Bandwidth with type Float32 on 2 MPI ranks

```
size (bytes),iterations,bandwidth (MB/s)
0,262144,0.0
4,262144,2.6990956834002654e6
8,262144,4.540782690018955e6
16,262144,7.765825179558593e6
32,262144,1.4923131558051359e7
64,262144,3.452298668581746e7
128,262144,5.474424784701676e7
256,262144,1.027131141041011e8
512,262144,2.3338038135801396e8
1024,262144,4.718019182044829e8
2048,131072,3.7915937310836136e8
4096,65536,2.953946705022236e8
8192,32768,2.6637536962888843e8
16384,16384,1.506649571850455e8
32768,8192,8.395105665004401e7
65536,4096,2.5888341311661247e7
131072,2048,1.9607578921437513e7
262144,1024,1.155979793648418e7
524288,512,4.848087236218043e6
1048576,256,2.948313270935728e6
----------------------------------------`
```