### PR TITLE
Added option to set the number of iterations

### DIFF
--- a/src/MPIBenchmarks.jl
+++ b/src/MPIBenchmarks.jl
@@ -8,7 +8,7 @@ export benchmark
 struct Configuration{T}
     T::Type{T}
     lengths::UnitRange{Int}
-    iters::Function
+    iters::Union{Function, Int}
     stdout::IO
     filename::Union{String,Nothing}
     synchronization_option::Union{String,Nothing}
@@ -24,7 +24,7 @@ function Configuration(T::Type;
                        stdout::Union{IO,Nothing}=nothing,
                        verbose::Bool=true,
                        filename::Union{String,Nothing}=nothing,
-                       iterations::Function=iterations,
+                       iterations::Union{Function, Int}=iterations,
                        synchronization_option::Union{String,Nothing}="lock",
                        )
     ispow2(max_size) || throw(ArgumentError("Maximum size must be a power of 2, found $(max_size)"))

--- a/src/imb_collective.jl
+++ b/src/imb_collective.jl
@@ -26,7 +26,7 @@ function run_imb_collective(benchmark::MPIBenchmark, func::Function, conf::Confi
 
     for s in conf.lengths
         size = 1 << s
-        iters = conf.iters(conf.T, s)
+        isa(conf.iters, Function) == true ?  iters = conf.iters(conf.T, s) : iters = conf.iters
         # Measure time on current rank
         time = func(conf.T, size, iters, comm)
 

--- a/src/imb_collective.jl
+++ b/src/imb_collective.jl
@@ -26,7 +26,7 @@ function run_imb_collective(benchmark::MPIBenchmark, func::Function, conf::Confi
 
     for s in conf.lengths
         size = 1 << s
-        isa(conf.iters, Function) == true ?  iters = conf.iters(conf.T, s) : iters = conf.iters
+        iters = conf.iters isa Function ?  conf.iters(conf.T, s) : conf.iters
         # Measure time on current rank
         time = func(conf.T, size, iters, comm)
 

--- a/src/imb_p2p.jl
+++ b/src/imb_p2p.jl
@@ -35,7 +35,7 @@ function run_imb_p2p(benchmark::MPIBenchmark, func::Function, conf::Configuratio
 
     for s in conf.lengths
         size = 1 << s
-        iters = conf.iters(conf.T, s)
+        isa(conf.iters, Function) == true ?  iters = conf.iters(conf.T, s) : iters = conf.iters
         # Measure time on current rank
         time, alloc = func(conf.T, size, iters, comm)
 

--- a/src/imb_p2p.jl
+++ b/src/imb_p2p.jl
@@ -35,7 +35,7 @@ function run_imb_p2p(benchmark::MPIBenchmark, func::Function, conf::Configuratio
 
     for s in conf.lengths
         size = 1 << s
-        isa(conf.iters, Function) == true ?  iters = conf.iters(conf.T, s) : iters = conf.iters
+        iters = conf.iters isa Function ?  conf.iters(conf.T, s) : conf.iters
         # Measure time on current rank
         time, alloc = func(conf.T, size, iters, comm)
 

--- a/src/osu_one_sided.jl
+++ b/src/osu_one_sided.jl
@@ -36,7 +36,7 @@ function run_osu_one_sided(benchmark::MPIBenchmark, func::Function, conf::Config
 
     for s in conf.lengths
         size = 1 << s
-        iters = conf.iters(conf.T, s)
+        isa(conf.iters, Function) == true ?  iters = conf.iters(conf.T, s) : iters = conf.iters
         # Measure time on current rank
         time = func(conf.T, size, iters, comm, conf.synchronization_option)
 

--- a/src/osu_one_sided.jl
+++ b/src/osu_one_sided.jl
@@ -36,7 +36,7 @@ function run_osu_one_sided(benchmark::MPIBenchmark, func::Function, conf::Config
 
     for s in conf.lengths
         size = 1 << s
-        isa(conf.iters, Function) == true ?  iters = conf.iters(conf.T, s) : iters = conf.iters
+        iters = conf.iters isa Function ?  conf.iters(conf.T, s) : conf.iters
         # Measure time on current rank
         time = func(conf.T, size, iters, comm, conf.synchronization_option)
 

--- a/src/osu_p2p.jl
+++ b/src/osu_p2p.jl
@@ -35,7 +35,7 @@ function run_osu_p2p(benchmark::MPIBenchmark, func::Function, conf::Configuratio
 
     for s in conf.lengths
         size = 1 << s
-        isa(conf.iters, Function) == true ?  iters = conf.iters(conf.T, s) : iters = conf.iters
+        iters = conf.iters isa Function ?  conf.iters(conf.T, s) : conf.iters
         # Measure time on current rank
         time = func(conf.T, size, iters, comm)
 

--- a/src/osu_p2p.jl
+++ b/src/osu_p2p.jl
@@ -35,7 +35,7 @@ function run_osu_p2p(benchmark::MPIBenchmark, func::Function, conf::Configuratio
 
     for s in conf.lengths
         size = 1 << s
-        iters = conf.iters(conf.T, s)
+        isa(conf.iters, Function) == true ?  iters = conf.iters(conf.T, s) : iters = conf.iters
         # Measure time on current rank
         time = func(conf.T, size, iters, comm)
 


### PR DESCRIPTION

mpiexec -n 2 julia --project -e 'using MPIBenchmarks; benchmark(OSUBw(; iterations=123))'

```
----------------------------------------
Running benchmark OSU Latency with type UInt8 on 2 MPI ranks

size (bytes),iterations,latency (seconds)
0,123,8.112046776748285e-7
1,123,2.704015592249428e-7
2,123,1.8608279344512196e-7
4,123,2.3163431059054243e-7
8,123,2.2291167964780233e-7
16,123,2.558638409870427e-7
32,123,2.6361729071392277e-7
64,123,2.7233992165666287e-7
128,123,5.534024742560658e-7
256,123,5.543716554719258e-7
512,123,9.992258335516706e-7
1024,123,1.9625919621165207e-6
2048,123,1.3859291386798146e-6
4096,123,3.8389267960215e-6
8192,123,3.068427729412792e-6
16384,123,2.5227787048836066e-6
32768,123,4.75674140744093e-6
65536,123,7.208769883566755e-6
131072,123,9.487314922053639e-6
262144,123,1.6524539730413174e-5
524288,123,3.619988759358724e-5
1048576,123,7.431487726971386e-5
2097152,123,0.00021933830850492649
4194304,123,0.000481911791049368
```