### PR TITLE
fixed OSUBw benchmark

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -5,6 +5,7 @@ version = "0.2.0"
 
 [deps]
 MPI = "da04e1cc-30fd-572f-bb4f-1f8673147195"
+Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
 
 [compat]
 MPI = "0.20"

--- a/src/osu_latency.jl
+++ b/src/osu_latency.jl
@@ -5,12 +5,25 @@ struct OSULatency{T} <: MPIBenchmark
     name::String
 end
 
+function osu_latency_iterations(::Type{T}, s::Int) where {T}
+    iter = 10000
+    if s < 0
+        buf_size = 0
+    else
+        buf_size = 2^s * sizeof(T)
+    end
+    if buf_size > 8192
+        iter = 1000
+    end
+    return iter
+end
+
 function OSULatency(T::Type=UInt8;
                      filename::Union{String,Nothing}="julia_osu_latency.csv",
                      kwargs...,
                      )
     return OSULatency{T}(
-        Configuration(T; filename, kwargs...),
+        Configuration(T; filename, max_size=2 ^ 22, iterations=osu_latency_iterations, kwargs...),
         "OSU Latency",
     )
 end

--- a/src/osu_p2p.jl
+++ b/src/osu_p2p.jl
@@ -23,17 +23,17 @@ function run_osu_p2p(benchmark::MPIBenchmark, func::Function, conf::Configuratio
 
     if iszero(rank)
         println(conf.stdout, "# ", benchmark.name, " with type ", conf.T, " on ", nranks, " MPI ranks")
-        if cal_bandwidth == false
-            println(conf.stdout, "size (bytes),iterations,latency (us)")
-        else
+        if cal_bandwidth
             println(conf.stdout, "size (bytes),iterations,bandwidth (MB/s)")
+        else
+            println(conf.stdout, "size (bytes),iterations,latency (us)")
         end
         if !isnothing(conf.filename)
             file = open(conf.filename, "w")
-            if cal_bandwidth == false
-                println(file, "size (bytes),iterations,latency (us)")
-            else
+            if cal_bandwidth
                 println(file, "size (bytes),iterations,bandwidth (MB/s)")
+            else
+                println(file, "size (bytes),iterations,latency (us)")
             end
         end
     end


### PR DESCRIPTION
The OSUBw benchmark wasn't working properly. The number of iterations was too large. The bandwidth wasn't computed properly and the final synchronizing MPI_Send/MPI_Recv pair exchange a too large message.
